### PR TITLE
Readme to include vamio patches as example, and whitespace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cpc {vendor}/{package} -n {patch-name}.patch -m {patch-message}
 - `composer`
 - `jq`
 - Standard Unix tools (`cp`, `mkdir`, `sed`, `date`)
-- Composer Patches Plugin: `cweagans/composer-patches`
+- Composer Patches Plugin: `cweagans/composer-patches` / `vaimo/composer-patches`
 
 ### Supported Environments
 - Linux
@@ -121,7 +121,7 @@ sudo mv cpc.sh /usr/local/bin/cpc
 - `-n, --name`: Specify custom patch filename
 - `-m, --message`: Add patch description
 
-Once the script execution is complete, run the `composer install` command to apply the patches.  
+Once the script execution is complete, run the `composer install` [ or `composer patch apply` if using `vaimo/composer-patches` ] command to apply the patches.  
 For more details, refer to the `Composer Configuration` section.
 
 > [!CAUTION]

--- a/src/composer-patch-creator.sh
+++ b/src/composer-patch-creator.sh
@@ -237,7 +237,7 @@ create_vendor_patch() {
 
     # Create patch
     log_message "${COLOR_GREEN}" "Creating patch file: ${patch_name}..."
-    git diff "./vendor/$vendor_package/" > "${patch_path}"
+    git diff -b "./vendor/$vendor_package/" > "${patch_path}"
     echo -e "✔ Done!"
 
     log_message "${COLOR_GREEN}" "Restoring/Un-staging the modified files..."


### PR DESCRIPTION
Simply update to readme to note that vamio patches can also be used.
Fix issue where diff can include whitespace changes.

Generally these are changes upon IDE save that changes \r\n (windows line endings) to \n (linux\mac)
It causes unneeded diff changes to be included in patch.
